### PR TITLE
AOSC OS is shipping mpv

### DIFF
--- a/installation/index.html
+++ b/installation/index.html
@@ -215,6 +215,15 @@
             </td>
           </tr>
           <tr class='package-row'>
+            <td>AOSC OS</td>
+            <td>
+              <a href='https://github.com/AOSC-Dev/aosc-os-abbs/tree/master/extra-multimedia/mpv'>
+                <i class='fa fa-globe'></i>
+                <span>https://github.com/AOSC-Dev/aosc-os-abbs/tree/master/extra-multimedia/mpv</span>
+              </a>
+            </td>
+          </tr>
+          <tr class='package-row'>
             <td>Arch (official)</td>
             <td>
               <a href='https://www.archlinux.org/packages/?q=mpv'>


### PR DESCRIPTION
Hi...

Just added a line for AOSC OS, which ships `mpv`.... The link provided points to the building manifest (configurations) for the package, while binary packages are available from its repository.

Best Regards,
Mingcong (Jeff) Bai
